### PR TITLE
Allow readable and derived stores as input

### DIFF
--- a/packages/trpc-svelte-query/package.json
+++ b/packages/trpc-svelte-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevm0/trpc-svelte-query",
-  "version": "0.12.0-canary",
+  "version": "0.13.0-canary",
   "description": "tRPC integration with @tanstack/svelte-query",
   "license": "MIT",
   "repository": {

--- a/packages/trpc-svelte-query/src/extensions/createReactiveQuery.ts
+++ b/packages/trpc-svelte-query/src/extensions/createReactiveQuery.ts
@@ -11,7 +11,7 @@
  */
 
 import { derived, get, readable, writable } from 'svelte/store'
-import type { Writable } from 'svelte/store'
+import type { Readable } from 'svelte/store'
 import { notifyManager, useQueryClient } from '@tanstack/svelte-query'
 import type {
   QueryObserver,
@@ -21,10 +21,10 @@ import type {
   QueryObserverOptions,
 } from '@tanstack/svelte-query'
 
-export type MaybeWritable<T> = T | Writable<T>
+export type MaybeReadable<T> = T | Readable<T>
 
-export const isWritable = <T>(obj: MaybeWritable<T>): obj is Writable<T> =>
-  obj != null && typeof obj === 'object' && 'subscribe' in obj && 'set' in obj && 'update' in obj
+export const isReadable = <T>(obj: MaybeReadable<T>): obj is Readable<T> =>
+  obj != null && typeof obj === 'object' && 'subscribe' in obj && typeof obj.subscribe === 'function'
 
 export function createReactiveQuery<
   TQueryFnData,
@@ -33,11 +33,11 @@ export function createReactiveQuery<
   TQueryData,
   TQueryKey extends QueryKey
 >(
-  options: MaybeWritable<QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>>,
+  options: MaybeReadable<QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>>,
   Observer: typeof QueryObserver,
   queryClient: QueryClient = useQueryClient()
 ): CreateQueryResult<TData, TError> {
-  const optionsStore = isWritable(options) ? options : writable(options)
+  const optionsStore = isReadable(options) ? options : writable(options)
 
   const defaultOptionsStore = derived(optionsStore, ($options) => {
     const defaultOptions = queryClient.defaultQueryOptions($options)

--- a/packages/trpc-svelte-query/src/proxies/svelteQuery/svelteQuery.ts
+++ b/packages/trpc-svelte-query/src/proxies/svelteQuery/svelteQuery.ts
@@ -14,7 +14,7 @@ import type {
 } from '@tanstack/svelte-query'
 import type { TRPCUntypedClient } from '@trpc/client'
 import type { AnyRouter, MaybePromise } from '@trpc/server'
-import { isWritable } from '../../extensions/createReactiveQuery'
+import { isReadable } from '../../extensions/createReactiveQuery'
 import { getQueryKeyInternal } from '../../helpers/getQueryKey'
 import type { SvelteQueryProxy, TRPCOptions } from './types'
 
@@ -47,7 +47,9 @@ export function createSvelteQueryProxy<T extends AnyRouter>(
 
     const path = pathCopy.join('.')
 
-    const input = isWritable(anyArgs[0]) ? get(anyArgs[0]) : anyArgs[0]
+    const inputIsReadable = isReadable(anyArgs[0])
+
+    const input = inputIsReadable ? get(anyArgs[0]) : anyArgs[0]
 
     const abortOnUnmount =
       Boolean(svelteQueryOptions?.abortOnUnmount) || Boolean(anyArgs[1]?.trpc?.abortOnUnmount)
@@ -64,7 +66,7 @@ export function createSvelteQueryProxy<T extends AnyRouter>(
           ...anyArgs[1],
         } satisfies CreateQueryOptions
 
-        if (!isWritable(anyArgs[0])) {
+        if (!inputIsReadable) {
           return createQuery(queryOptions)
         }
 
@@ -104,7 +106,7 @@ export function createSvelteQueryProxy<T extends AnyRouter>(
           ...anyArgs[1],
         } satisfies CreateInfiniteQueryOptions
 
-        if (!isWritable(anyArgs[0])) {
+        if (!isReadable(anyArgs[0])) {
           return createInfiniteQuery(infiniteQueryOptions)
         }
 


### PR DESCRIPTION
Currently, the only stores that can be used as an input are writables. The only methods being used on these stores is the `subscribe` method. This pull request widens the type to allow readable and derived stores as currently providing them results in an empty object being sent to TRPC as a runtime check is checking for `set` and `update` methods.

This allows for code like the following; which now reactively updates correctly
```ts
const example = data.trpc.getPost.createQuery(
  derived(page, $page => ({
    slug: $page.params.slug,
  }))
);
```

Currently as a workaround, I can decorate an object with noops for the set and update so that this check passes, but this is extremely annoying and inefficient. Either this or I put the query inside a reactive statement which also causes further issues with anything that requires the query object in the script tag as reactive statements are hoisted to the bottom of the script.